### PR TITLE
Laravel rule for enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ abstract class Enum extends BaseEnum
     @endforeach
 </select>
 ```
+Validation Rule:
+
+``` php
+use Nasyrov\Laravel\Enums\Rules\EnumRule;
+
+$validator = Validator::make($request->all(), [
+    'enum' => new EnumRule(UserStatusEnum::class),
+]);
+```
+
+
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require": {
         "php": ">=7.0",
         "illuminate/console": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/support": "5.5.*",
+        "illuminate/contracts": "5.5.*"
     },
     "require-dev": {
         "orchestra/testbench": "~3.5",

--- a/src/Rules/EnumRule.php
+++ b/src/Rules/EnumRule.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Nasyrov\Laravel\Enums\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Nasyrov\Laravel\Enums\Enum;
+use ReflectionClass;
+use InvalidArgumentException;
+
+class EnumRule implements Rule
+{
+    /** @property string $enumClass */
+    protected $enumClass;
+
+    /**
+    * @param string $enumClass Class of the enum to validate against
+    */
+    public function __construct(string $enumClass)
+    {
+        if ($this->validateEnumClass($enumClass)) {
+            throw new InvalidArgumentException(
+                $this->invalidEnumMessage($enumClass)
+            );
+        }
+
+        $this->enumClass = $enumClass;
+    }
+
+    /**
+     * Determine if the validation rule is an valid enum.
+     *
+     * @param string $attribute
+     * @param mixed  $value
+     *
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        $values = $this->enumClass::constants()->flip();
+
+        return $values->has($value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        $enumClassName = explode('\\', $this->enumClass);
+
+        return 'The :attribute it not a valid value for the ' . array_pop($enumClassName);
+    }
+
+    /**
+     * Validate that the given class is an Enum
+     *
+     * @param string $enumClass
+     *
+     * @return bool
+     */
+    protected function validateEnumClass(string $enumClass): bool
+    {
+        return !class_exists($enumClass)
+            || !(new ReflectionClass($enumClass))->isSubclassOf(Enum::class);
+    }
+
+    /**
+     * Pretty error message to indicate which class to implement
+     *
+     * @param string $enumClass
+     *
+     * @return string
+     */
+    protected function invalidEnumMessage(string $enumClass): string
+    {
+        return sprintf(
+            '%s needs to be valid and implement %s for the EnumRule',
+            $enumClass,
+            Enum::class
+        );
+    }
+}

--- a/tests/Unit/EnumRuleTest.php
+++ b/tests/Unit/EnumRuleTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Nasyrov\Laravel\Enums\Tests\Unit;
+
+use Illuminate\Validation\Factory;
+use Nasyrov\Laravel\Enums\Rules\EnumRule;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Translation\FileLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Container\Container;
+use InvalidArgumentException;
+
+class EnumRuleTest extends TestCase
+{
+    /** @test */
+    public function enum_rule_is_valid()
+    {
+        $validator = $this->validator(
+            [
+                'enum' => 'test',
+            ],
+            [
+                'enum' => new EnumRule(EnumFixture::class),
+            ]
+        );
+
+        $this->assertTrue(!$validator->fails());
+    }
+
+    /** @test */
+    public function enum_rule_is_invalid()
+    {
+        $validator = $this->validator(
+            [
+                'enum' => 'wrongenum',
+            ],
+            [
+                'enum' => new EnumRule(EnumFixture::class),
+            ]
+        );
+
+        $this->assertTrue($validator->fails());
+
+        $this->assertEquals(
+            [
+                'The enum it not a valid value for the EnumFixture'
+            ],
+            $validator->errors()->toArray()['enum']
+        );
+    }
+
+    /** @test */
+    public function enum_rule_bad_class()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new EnumRule('bad class');
+    }
+
+    protected function validator($attributes, $rules)
+    {
+        $loader = new FileLoader(new Filesystem, 'lang');
+        $translator = new Translator($loader, 'en');
+        $validation = new Factory($translator, new Container);
+
+
+        return $validation->make($attributes, $rules);
+    }
+}


### PR DESCRIPTION
Feature: Add Laravel rule to validate that a value is defined in a specific enum.

Reason: Going to use this in a project, where we validate aggressively and would be a nice abstraction to have.

Test: Defined 3 tests for the implementation, thou first run in a new project goes through without problems, extra runs will make EnumMakeCommandTest::it_can_run_the_command fail, but seems like it is not related to my code if you have a fix for this I would enjoy it :+1:

Linting is approved and commits are clean if you have suggestions, code styles or anything feel free to suggest them.